### PR TITLE
feat(gateway): harden provider catalog and expose compatibility flag

### DIFF
--- a/apps/gateway/internal/domain/models.go
+++ b/apps/gateway/internal/domain/models.go
@@ -139,6 +139,8 @@ type ModelLimit struct {
 type ProviderInfo struct {
 	ID                 string      `json:"id"`
 	Name               string      `json:"name"`
+	DisplayName        string      `json:"display_name"`
+	OpenAICompatible   bool        `json:"openai_compatible"`
 	APIKeyPrefix       string      `json:"api_key_prefix"`
 	Models             []ModelInfo `json:"models"`
 	AllowCustomBaseURL bool        `json:"allow_custom_base_url"`

--- a/apps/gateway/internal/provider/catalog.go
+++ b/apps/gateway/internal/provider/catalog.go
@@ -120,6 +120,15 @@ func ResolveProvider(providerID string) ProviderSpec {
 	}
 }
 
+func IsBuiltinProviderID(providerID string) bool {
+	id := strings.ToLower(strings.TrimSpace(providerID))
+	if id == "" {
+		return false
+	}
+	_, ok := builtinProviders[id]
+	return ok
+}
+
 func ResolveAdapter(providerID string) string {
 	return ResolveProvider(providerID).Adapter
 }

--- a/apps/gateway/internal/repo/store_test.go
+++ b/apps/gateway/internal/repo/store_test.go
@@ -1,0 +1,77 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"copaw-next/apps/gateway/internal/provider"
+)
+
+func TestLoadMigratesLegacyActiveCustomProviderToOpenAI(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	raw := `{
+  "providers": {
+    "demo": {"enabled": true},
+    "openai": {"enabled": true},
+    "custom-openai": {
+      "api_key": "sk-legacy",
+      "base_url": "http://127.0.0.1:19002/v1",
+      "display_name": "Legacy Gateway",
+      "enabled": true,
+      "headers": {"X-Test": "1"},
+      "timeout_ms": 12000,
+      "model_aliases": {"fast": "gpt-4o-mini"}
+    }
+  },
+  "active_llm": {"provider_id": "custom-openai", "model": "legacy-model"}
+}`
+	if err := os.WriteFile(statePath, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write state failed: %v", err)
+	}
+
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("new store failed: %v", err)
+	}
+
+	store.Read(func(st *State) {
+		if len(st.Providers) != 2 {
+			t.Fatalf("expected only builtin providers, got=%d", len(st.Providers))
+		}
+		if _, ok := st.Providers["demo"]; !ok {
+			t.Fatalf("demo provider should exist")
+		}
+		openai, ok := st.Providers["openai"]
+		if !ok {
+			t.Fatalf("openai provider should exist")
+		}
+		if _, ok := st.Providers["custom-openai"]; ok {
+			t.Fatalf("custom provider should be removed after migration")
+		}
+
+		if openai.DisplayName != "Legacy Gateway" {
+			t.Fatalf("expected display_name migrated, got=%q", openai.DisplayName)
+		}
+		if openai.APIKey != "sk-legacy" {
+			t.Fatalf("expected api_key migrated, got=%q", openai.APIKey)
+		}
+		if openai.BaseURL != "http://127.0.0.1:19002/v1" {
+			t.Fatalf("expected base_url migrated, got=%q", openai.BaseURL)
+		}
+		if openai.TimeoutMS != 12000 {
+			t.Fatalf("expected timeout_ms migrated, got=%d", openai.TimeoutMS)
+		}
+		if openai.ModelAliases["fast"] != "gpt-4o-mini" {
+			t.Fatalf("expected model_aliases migrated, got=%v", openai.ModelAliases)
+		}
+
+		if st.ActiveLLM.ProviderID != "openai" {
+			t.Fatalf("expected active provider migrated to openai, got=%q", st.ActiveLLM.ProviderID)
+		}
+		if st.ActiveLLM.Model != provider.DefaultModelID("openai") {
+			t.Fatalf("expected active model fallback to openai default, got=%q", st.ActiveLLM.Model)
+		}
+	})
+}

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -220,6 +220,19 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ProviderInfo' }
+  /models/{provider_id}:
+    delete:
+      parameters:
+        - in: path
+          name: provider_id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DeleteResult' }
   /models/active:
     get:
       responses:
@@ -529,6 +542,8 @@ components:
       properties:
         id: { type: string, minLength: 1 }
         name: { type: string, minLength: 1 }
+        display_name: { type: string, minLength: 1 }
+        openai_compatible: { type: boolean }
         api_key_prefix: { type: string, minLength: 1 }
         models:
           type: array
@@ -539,12 +554,13 @@ components:
         current_api_key: { type: string }
         current_base_url: { type: string }
       required:
-        [id, name, api_key_prefix, models, allow_custom_base_url, enabled, has_api_key, current_api_key, current_base_url]
+        [id, name, display_name, openai_compatible, api_key_prefix, models, allow_custom_base_url, enabled, has_api_key, current_api_key, current_base_url]
     ProviderConfigPatch:
       type: object
       properties:
         api_key: { type: string }
         base_url: { type: string }
+        display_name: { type: string }
         enabled: { type: boolean }
         headers:
           type: object
@@ -553,6 +569,11 @@ components:
         model_aliases:
           type: object
           additionalProperties: { type: string }
+    DeleteResult:
+      type: object
+      properties:
+        deleted: { type: boolean }
+      required: [deleted]
     ModelCatalogInfo:
       type: object
       properties:

--- a/packages/sdk-ts/src/generated.ts
+++ b/packages/sdk-ts/src/generated.ts
@@ -4,7 +4,7 @@
 
 export const OPENAPI_VERSION = "3.0.3" as const;
 
-export type APIPath = "/agent/process" | "/chats" | "/chats/{chat_id}" | "/chats/batch-delete" | "/config/channels" | "/config/channels/{channel_name}" | "/config/channels/types" | "/cron/jobs" | "/cron/jobs/{job_id}" | "/cron/jobs/{job_id}/pause" | "/cron/jobs/{job_id}/resume" | "/cron/jobs/{job_id}/run" | "/cron/jobs/{job_id}/state" | "/envs" | "/envs/{key}" | "/healthz" | "/models" | "/models/{provider_id}/config" | "/models/active" | "/models/catalog" | "/skills" | "/skills/{skill_name}" | "/skills/{skill_name}/disable" | "/skills/{skill_name}/enable" | "/skills/{skill_name}/files/{source}/{file_path}" | "/skills/available" | "/skills/batch-disable" | "/skills/batch-enable" | "/version" | "/workspace/download" | "/workspace/upload";
+export type APIPath = "/agent/process" | "/chats" | "/chats/{chat_id}" | "/chats/batch-delete" | "/config/channels" | "/config/channels/{channel_name}" | "/config/channels/types" | "/cron/jobs" | "/cron/jobs/{job_id}" | "/cron/jobs/{job_id}/pause" | "/cron/jobs/{job_id}/resume" | "/cron/jobs/{job_id}/run" | "/cron/jobs/{job_id}/state" | "/envs" | "/envs/{key}" | "/healthz" | "/models" | "/models/{provider_id}" | "/models/{provider_id}/config" | "/models/active" | "/models/catalog" | "/skills" | "/skills/{skill_name}" | "/skills/{skill_name}/disable" | "/skills/{skill_name}/enable" | "/skills/{skill_name}/files/{source}/{file_path}" | "/skills/available" | "/skills/batch-disable" | "/skills/batch-enable" | "/version" | "/workspace/download" | "/workspace/upload";
 
 export type APIMethodByPath = {
   "/agent/process": "post";
@@ -24,6 +24,7 @@ export type APIMethodByPath = {
   "/envs/{key}": "delete";
   "/healthz": "get";
   "/models": "get";
+  "/models/{provider_id}": "delete";
   "/models/{provider_id}/config": "put";
   "/models/active": "get" | "put";
   "/models/catalog": "get";

--- a/tests/contract/openapi.lint.mjs
+++ b/tests/contract/openapi.lint.mjs
@@ -34,6 +34,7 @@ const activeModelsInfo = schemas.ActiveModelsInfo;
 const modelInfo = schemas.ModelInfo;
 const providerInfo = schemas.ProviderInfo;
 const providerConfigPatch = schemas.ProviderConfigPatch;
+const deleteResult = schemas.DeleteResult;
 const modelCatalogInfo = schemas.ModelCatalogInfo;
 const apiKeyAuth = spec?.components?.securitySchemes?.ApiKeyAuth;
 
@@ -96,9 +97,15 @@ expect(hasRequired(modelSlotConfig, "model"), "ModelSlotConfig.required 必须�
 expect(hasRequired(activeModelsInfo, "active_llm"), "ActiveModelsInfo.required 必须包含 active_llm");
 expect(hasRequired(modelInfo, "id"), "ModelInfo.required 必须包含 id");
 expect(hasRequired(modelInfo, "name"), "ModelInfo.required 必须包含 name");
+expect(providerInfo?.properties?.display_name?.minLength === 1, "ProviderInfo.display_name 必须设置 minLength=1");
+expect(hasRequired(providerInfo, "display_name"), "ProviderInfo.required 必须包含 display_name");
+expect(providerInfo?.properties?.openai_compatible?.type === "boolean", "ProviderInfo.openai_compatible 必须是 boolean");
+expect(hasRequired(providerInfo, "openai_compatible"), "ProviderInfo.required 必须包含 openai_compatible");
 expect(providerInfo?.properties?.enabled?.type === "boolean", "ProviderInfo.enabled 必须是 boolean");
 expect(hasRequired(providerInfo, "models"), "ProviderInfo.required 必须包含 models");
 expect(providerConfigPatch?.properties?.timeout_ms?.minimum === 0, "ProviderConfigPatch.timeout_ms 必须设置 minimum=0");
+expect(deleteResult?.properties?.deleted?.type === "boolean", "DeleteResult.deleted 必须是 boolean");
+expect(hasRequired(deleteResult, "deleted"), "DeleteResult.required 必须包含 deleted");
 expect(hasRequired(modelCatalogInfo, "providers"), "ModelCatalogInfo.required 必须包含 providers");
 expect(hasRequired(modelCatalogInfo, "defaults"), "ModelCatalogInfo.required 必须包含 defaults");
 expect(hasRequired(modelCatalogInfo, "active_llm"), "ModelCatalogInfo.required 必须包含 active_llm");

--- a/tests/contract/openapi.test.mjs
+++ b/tests/contract/openapi.test.mjs
@@ -14,6 +14,7 @@ const requiredPaths = [
   "/cron/jobs",
   "/models",
   "/models/catalog",
+  "/models/{provider_id}",
   "/envs",
   "/skills",
   "/workspace/upload",


### PR DESCRIPTION
## 变更说明
- Provider 管理仅允许内置 provider，补齐删除接口与相关错误码。
- state 加载阶段将历史自定义 provider 迁移到 `openai`，并持久化 `display_name`。
- `/models` 与 `/models/catalog` 的 `ProviderInfo` 新增 `openai_compatible` 字段，供前端识别 OpenAI 兼容接口。
- 同步更新 OpenAPI 契约、contract lint/test 与 sdk-ts 生成产物。

## 测试说明
- `cd apps/gateway && go test ./...`
- `pnpm --filter @copaw-next/tests-contract run lint && pnpm --filter @copaw-next/tests-contract run test`

## 回滚说明
- 若需回滚，revert 本 PR 即可恢复原 provider 管理行为与契约字段。
- 回滚后建议重新执行 contract 与 gateway 测试，确保 SDK 与接口契约一致。
