### PR TITLE
feat(gateway,web): enable shell tool calls from chat

### DIFF
--- a/apps/gateway/internal/app/server_test.go
+++ b/apps/gateway/internal/app/server_test.go
@@ -193,6 +193,92 @@ func TestProcessAgentDispatchesToWebhookChannel(t *testing.T) {
 	}
 }
 
+func TestProcessAgentRunsShellTool(t *testing.T) {
+	t.Setenv("NEXTAI_ENABLE_SHELL_TOOL", "true")
+	srv := newTestServer(t)
+
+	procReq := `{
+		"input":[{"role":"user","type":"message","content":[{"type":"text","text":"/shell printf hello"}]}],
+		"session_id":"s-shell",
+		"user_id":"u-shell",
+		"channel":"console",
+		"stream":false,
+		"biz_params":{"tool":{"name":"shell","input":{"command":"printf hello"}}}
+	}`
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/agent/process", strings.NewReader(procReq)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("process status=%d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "hello") {
+		t.Fatalf("expected shell output in reply body, got=%s", w.Body.String())
+	}
+}
+
+func TestProcessAgentRejectsUnknownTool(t *testing.T) {
+	srv := newTestServer(t)
+
+	procReq := `{
+		"input":[{"role":"user","type":"message","content":[{"type":"text","text":"run desktop"}]}],
+		"session_id":"s-tool-unknown",
+		"user_id":"u-tool-unknown",
+		"channel":"console",
+		"stream":false,
+		"biz_params":{"tool":{"name":"desktop","input":{}}}
+	}`
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/agent/process", strings.NewReader(procReq)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got=%d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"code":"tool_not_supported"`) {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestProcessAgentRejectsShellToolWhenDisabled(t *testing.T) {
+	srv := newTestServer(t)
+
+	procReq := `{
+		"input":[{"role":"user","type":"message","content":[{"type":"text","text":"/shell pwd"}]}],
+		"session_id":"s-shell-disabled",
+		"user_id":"u-shell-disabled",
+		"channel":"console",
+		"stream":false,
+		"biz_params":{"tool":{"name":"shell","input":{"command":"pwd"}}}
+	}`
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/agent/process", strings.NewReader(procReq)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got=%d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"code":"tool_disabled"`) {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestProcessAgentRejectsShellToolWithoutCommand(t *testing.T) {
+	t.Setenv("NEXTAI_ENABLE_SHELL_TOOL", "true")
+	srv := newTestServer(t)
+
+	procReq := `{
+		"input":[{"role":"user","type":"message","content":[{"type":"text","text":"/shell"}]}],
+		"session_id":"s-shell-empty",
+		"user_id":"u-shell-empty",
+		"channel":"console",
+		"stream":false,
+		"biz_params":{"tool":{"name":"shell","input":{}}}
+	}`
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/agent/process", strings.NewReader(procReq)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got=%d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"code":"invalid_tool_input"`) {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+}
+
 func TestWorkspaceUploadRejectUnsafePath(t *testing.T) {
 	srv := newTestServer(t)
 

--- a/apps/gateway/internal/plugin/shell.go
+++ b/apps/gateway/internal/plugin/shell.go
@@ -1,0 +1,144 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	shellToolEnableEnv      = "NEXTAI_ENABLE_SHELL_TOOL"
+	shellToolDefaultTimeout = 20 * time.Second
+	shellToolMaxTimeout     = 120 * time.Second
+	shellToolMaxOutputBytes = 16 * 1024
+)
+
+var (
+	ErrShellToolDisabled       = errors.New("shell_tool_disabled")
+	ErrShellToolCommandMissing = errors.New("shell_tool_command_missing")
+)
+
+type ShellTool struct{}
+
+func NewShellTool() *ShellTool {
+	return &ShellTool{}
+}
+
+func (t *ShellTool) Name() string {
+	return "shell"
+}
+
+func (t *ShellTool) Invoke(input map[string]interface{}) (map[string]interface{}, error) {
+	if !envEnabled(os.Getenv(shellToolEnableEnv)) {
+		return nil, ErrShellToolDisabled
+	}
+	command := strings.TrimSpace(stringValue(input["command"]))
+	if command == "" {
+		return nil, ErrShellToolCommandMissing
+	}
+
+	timeout := parseShellTimeout(input["timeout_seconds"])
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-lc", command)
+	if cwd := strings.TrimSpace(stringValue(input["cwd"])); cwd != "" {
+		cmd.Dir = cwd
+	}
+
+	outputBytes, err := cmd.CombinedOutput()
+	output := truncateOutput(string(outputBytes), shellToolMaxOutputBytes)
+	ok := err == nil
+	exitCode := 0
+
+	if err != nil {
+		var exitErr *exec.ExitError
+		switch {
+		case errors.As(err, &exitErr):
+			exitCode = exitErr.ExitCode()
+		case errors.Is(ctx.Err(), context.DeadlineExceeded):
+			exitCode = 124
+		default:
+			exitCode = -1
+		}
+	}
+
+	text := formatShellText(command, ok, exitCode, output)
+	return map[string]interface{}{
+		"ok":        ok,
+		"command":   command,
+		"exit_code": exitCode,
+		"output":    output,
+		"text":      text,
+	}, nil
+}
+
+func envEnabled(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseShellTimeout(raw interface{}) time.Duration {
+	seconds := int64(shellToolDefaultTimeout / time.Second)
+	switch value := raw.(type) {
+	case float64:
+		seconds = int64(value)
+	case int:
+		seconds = int64(value)
+	case int64:
+		seconds = value
+	case string:
+		if parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64); err == nil {
+			seconds = parsed
+		}
+	}
+	if seconds <= 0 {
+		seconds = int64(shellToolDefaultTimeout / time.Second)
+	}
+	maxSeconds := int64(shellToolMaxTimeout / time.Second)
+	if seconds > maxSeconds {
+		seconds = maxSeconds
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func truncateOutput(raw string, maxBytes int) string {
+	if maxBytes <= 0 || len(raw) <= maxBytes {
+		return raw
+	}
+	return raw[:maxBytes] + "\n... (output truncated)"
+}
+
+func formatShellText(command string, ok bool, exitCode int, output string) string {
+	trimmed := strings.TrimSpace(output)
+	if ok {
+		if trimmed == "" {
+			return fmt.Sprintf("$ %s\n(command completed with no output)", command)
+		}
+		return fmt.Sprintf("$ %s\n%s", command, trimmed)
+	}
+	if trimmed == "" {
+		return fmt.Sprintf("$ %s\n(command failed with exit code %d)", command, exitCode)
+	}
+	return fmt.Sprintf("$ %s\n(command failed with exit code %d)\n%s", command, exitCode, trimmed)
+}
+
+func stringValue(v interface{}) string {
+	switch value := v.(type) {
+	case string:
+		return value
+	case fmt.Stringer:
+		return value.String()
+	default:
+		return ""
+	}
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -668,6 +668,14 @@ async function sendMessage(): Promise<void> {
     return;
   }
 
+  let bizParams: Record<string, unknown> | undefined;
+  try {
+    bizParams = parseChatBizParams(inputText);
+  } catch (error) {
+    setStatus(asErrorMessage(error), "error");
+    return;
+  }
+
   state.sending = true;
   sendButton.disabled = true;
   const assistantID = `assistant-${Date.now()}`;
@@ -689,7 +697,7 @@ async function sendMessage(): Promise<void> {
   setStatus(t("status.streamingReply"), "info");
 
   try {
-    await streamReply(inputText, (delta) => {
+    await streamReply(inputText, bizParams, (delta) => {
       const target = state.messages.find((item) => item.id === assistantID);
       if (!target) {
         return;
@@ -717,14 +725,21 @@ async function sendMessage(): Promise<void> {
   }
 }
 
-async function streamReply(userText: string, onDelta: (delta: string) => void): Promise<void> {
-  const payload = {
+async function streamReply(
+  userText: string,
+  bizParams: Record<string, unknown> | undefined,
+  onDelta: (delta: string) => void,
+): Promise<void> {
+  const payload: Record<string, unknown> = {
     input: [{ role: "user", type: "message", content: [{ type: "text", text: userText }] }],
     session_id: state.activeSessionId,
     user_id: state.userId,
     channel: state.channel,
     stream: true,
   };
+  if (bizParams && Object.keys(bizParams).length > 0) {
+    payload.biz_params = bizParams;
+  }
 
   const response = await fetch(toAbsoluteURL("/agent/process"), {
     method: "POST",
@@ -767,6 +782,25 @@ async function streamReply(userText: string, onDelta: (delta: string) => void): 
   if (!doneReceived) {
     throw new Error(t("error.sseEndedEarly"));
   }
+}
+
+function parseChatBizParams(inputText: string): Record<string, unknown> | undefined {
+  const trimmed = inputText.trim();
+  if (!trimmed.startsWith("/shell")) {
+    return undefined;
+  }
+  const command = trimmed.slice("/shell".length).trim();
+  if (command === "") {
+    throw new Error("shell command is required after /shell");
+  }
+  return {
+    tool: {
+      name: "shell",
+      input: {
+        command,
+      },
+    },
+  };
 }
 
 function consumeSSEBuffer(raw: string, onDelta: (delta: string) => void): { done: boolean; rest: string } {


### PR DESCRIPTION
## 变更说明

本 PR 为聊天链路补齐最小“电脑操作”能力（先支持 shell）：

- Gateway 新增 `shell` 工具插件：`apps/gateway/internal/plugin/shell.go`
  - 默认关闭，需显式设置 `NEXTAI_ENABLE_SHELL_TOOL=true`
  - 支持输入参数：`command`、`cwd`、`timeout_seconds`
  - 返回结构化结果并生成可直接展示的 `text`
- `/agent/process` 接入 `biz_params.tool` 调用链：`apps/gateway/internal/app/server.go`
  - 兼容原有模型回复逻辑
  - 新增工具错误映射：`tool_not_supported`、`tool_disabled`、`invalid_tool_input`
- Web 聊天支持 `/shell <command>` 指令：`apps/web/src/main.ts`
  - 发送时自动构造 `biz_params.tool` 请求
  - 非 `/shell` 消息保持原行为

## 测试说明

已执行并通过：

- `cd apps/gateway && go test ./...`
- `pnpm -C apps/web test`
- `pnpm -C apps/web build`

并新增回归测试：

- `apps/gateway/internal/app/server_test.go`
  - `TestProcessAgentRunsShellTool`
  - `TestProcessAgentRejectsUnknownTool`
  - `TestProcessAgentRejectsShellToolWhenDisabled`
  - `TestProcessAgentRejectsShellToolWithoutCommand`

## 回滚说明

若需回滚本 PR：

1. `git revert e5349ab`
2. 重启 Gateway（若已启用 `NEXTAI_ENABLE_SHELL_TOOL`，可同时移除该环境变量）
